### PR TITLE
Fix Debian 12: switch to ntpsec and update ntp config path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
   changed_when: false
 
 - name: update system date manually
-  shell: ntpdate 1.us.pool.ntp.org
+  shell: ntpdate 1.north-america.pool.ntp.org
   when:
     - not ntp_installed.stat.exists | bool
 

--- a/vars/Debian-12.yml
+++ b/vars/Debian-12.yml
@@ -1,0 +1,6 @@
+ntp_packages:
+  - python3-apt
+  - ntpsec
+  - ntpsec-ntpdate
+ntp_service: ntpsec
+ntp_config: /etc/ntpsec/ntp.conf


### PR DESCRIPTION
## What changed
- Updated NTP server in `tasks/main.yml` from `1.us.pool.ntp.org` to `1.north-america.pool.ntp.org`
- Created `vars/Debian-12.yml` with ntpsec-specific packages and config path

## Why
Debian 12 (Bookworm) ships `ntpsec` instead of the legacy `ntp` package.
Without a dedicated `Debian-12.yml` vars file, the role falls back to
`Debian.yml` which installs the wrong packages and points to the wrong
config path `/etc/ntp.conf` instead of `/etc/ntpsec/ntp.conf`.

## Files changed
- `tasks/main.yml` — updated ntpdate server to north-america pool
- `vars/Debian-12.yml` — new file for Debian 12 specific vars

